### PR TITLE
fix: deprecation warning

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -37,7 +37,7 @@ export default defineNuxtModule<ModuleOptions>({
     alias: []
   },
   setup (options, nuxt) {
-    const names = []
+    const imports = []
     const prefix = options.prefix || ''
     const aliasMap = new Map(options.alias)
     const exludes = [...options.exclude, ...exculdeDefaults]
@@ -49,7 +49,7 @@ export default defineNuxtModule<ModuleOptions>({
           const isPrefix = !options.prefixSkip.some(key => alias.startsWith(key)) && prefix
           return isPrefix ? prefix + lodash.upperFirst(alias) : alias
         })()
-        names.push({ name, as })
+        imports.push({ name, as })
       }
     }
 
@@ -60,7 +60,7 @@ export default defineNuxtModule<ModuleOptions>({
     })
 
     nuxt.hook('autoImports:sources', (sources) => {
-      sources.push({ names, from: 'lodash-es' })
+      sources.push({ imports, from: 'lodash-es' })
     })
   }
 })


### PR DESCRIPTION
According to [**_nuxt3 changes in here_**](https://github.com/nuxt/framework/blob/114cbe33d05846d33ceed2819a413b9780475bec/packages/nuxt3/src/auto-imports/module.ts#L30) `names` changed to `imports`

Current behavior - `names` works, but throws deprecation warning