### PR TITLE
fix: duplicate imports on hot reload

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -60,6 +60,9 @@ export default defineNuxtModule<ModuleOptions>({
     })
 
     nuxt.hook('autoImports:sources', (sources) => {
+      if (sources.find(i => i.from === 'lodash-es'))
+          return
+
       sources.push({ names, from: 'lodash-es' })
     })
   }


### PR DESCRIPTION
Current behavior - on hot reload shows warning about duplicate imports

Fix - omit import it exists in the sources