### PR TITLE
fix: add head to exclude list

### DIFF
--- a/src/exclude.ts
+++ b/src/exclude.ts
@@ -19,5 +19,6 @@ export default [
   'plant',
   'next',
   'default',
-  'commit'
+  'commit',
+  'head'
 ]


### PR DESCRIPTION
added `head` to exclude list by default as it is same as `first`. U can also alias `first` back to `head` when using different prefix.
closes #9 